### PR TITLE
Update requirements list to prepare for qiskit 1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qiskit-terra>=0.24.0
+qiskit>=0.43.0
 rustworkx>=0.12.0


### PR DESCRIPTION
Starting in the Qiskit 1.0.0 release there will only be a Qiskit package. Unfortunately pip is not able to deal with the overlap between the qiskit and qiskit-terra packages, see:

https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0#for-developers

for details on this. The qiskit-qubit-reuse plugin is compatible with the API changes in Qiskit 1.0.0 (I tested this with qiskit 1.0.0rc1), but we need to update the requirements so that when users on Qiskit 1.0.0 install qiskit-qubit-reuse it doesn't break the python environment. This commit makes the appropriate change to the requirements list and changes the current qiskit-terra>=0.24.0 to qiskit>=0.43.0 (which is the metapackage release on 0.*) corresponding to qiskit-terra 0.24.0.