### PR TITLE
Bump version to prepare for 0.0.2 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name="qiskit-qubit-reuse",
-    version="0.0.1",
+    version="0.0.2",
     description="A Qiskit's compiler plugin to reuse qubits using midcircuit measurement",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This commit bumps the package version to 0.0.2, to prepare for releasing that version. This will be a small release that changes the requirements list to fix compatibility with Qiskit 1.0.0.