### PR TITLE
Fix: Add compatibility with Qiskit 2.0

### DIFF
--- a/qiskit_qubit_reuse/plugin.py
+++ b/qiskit_qubit_reuse/plugin.py
@@ -26,28 +26,19 @@ def generate_optimization_manager(pass_manager_config, optimization_level=None, 
         optimization_level=optimization_level,
         target=pass_manager_config.target,
         basis_gates=pass_manager_config.basis_gates,
-        inst_map=pass_manager_config.inst_map,
-        backend_properties=pass_manager_config.backend_properties,
-        instruction_durations=pass_manager_config.instruction_durations,
-        timing_constraints=pass_manager_config.timing_constraints,
     )
     # Try and get init attribute, if nonexistent, create a regular pass
-    plugin_stage = getattr(
-        preset_stage,
-        "init",
-        PassManager(
-            [
-                UnitarySynthesis(
-                    target=pass_manager_config.target,
-                    basis_gates=pass_manager_config.basis_gates,
-                    backend_props=pass_manager_config.backend_properties,
-                ),
-                Unroll3qOrMore(
-                    target=pass_manager_config.target,
-                    basis_gates=pass_manager_config.basis_gates,
-                ),
-            ]
-        ),
+    plugin_stage = getattr(preset_stage, "init", None) or PassManager(
+        [
+            UnitarySynthesis(
+                target=pass_manager_config.target,
+                basis_gates=pass_manager_config.basis_gates,
+            ),
+            Unroll3qOrMore(
+                target=pass_manager_config.target,
+                basis_gates=pass_manager_config.basis_gates,
+            ),
+        ]
     )
     # Append qubit reuse.
     plugin_stage.append(QubitReuse(target=pass_manager_config.target, type=type))

--- a/qiskit_qubit_reuse/qubit_reuse_greedy.py
+++ b/qiskit_qubit_reuse/qubit_reuse_greedy.py
@@ -117,27 +117,26 @@ class Greedy:
                 # Check if any of the qubits in qargs has not been added to the reduced circuit.
                 if not current_node.op.name == "barrier":
                     for op_qubit in current_node.qargs:
-                        # if self.__qubit_mapping.get(self.__qubit_indices[op_qubit], None) == None:
-                        #     # If the qubit has not been added, make the recursion call,
-                        #       make it stop at current node.
                         self.__create_subpath(op_qubit, until_node=current_node)
                     # Apply the operation, check for condition
-                    if current_node.op.condition:
+                    if hasattr(current_node.op, "condition"):
                         oper = copy.copy(current_node.op)
                         oper.condition = (self.__creg, oper.condition[1])
                     else:
                         oper = current_node.op
+                    new_qargs = tuple(
+                        self.dag.qubits[self.__qubit_mapping[self.__qubit_indices[qbit]]]
+                        for qbit in current_node.qargs
+                    )
+                    new_cargs = tuple(
+                        self.dag.clbits[self.__cl_indices[clbit]] for clbit in current_node.cargs
+                    )
                     self.dag.apply_operation_back(
                         op=oper,
-                        qargs=(
-                            self.dag.qubits[self.__qubit_mapping[self.__qubit_indices[qbit]]]
-                            for qbit in current_node.qargs
-                        ),
-                        cargs=(
-                            self.dag.clbits[self.__cl_indices[clbit]]
-                            for clbit in current_node.cargs
-                        ),
+                        qargs=new_qargs,
+                        cargs=new_cargs,
                     )
+
                 # If measuring, add the qubit to the list of available qubits.
                 if (
                     not self.__dual


### PR DESCRIPTION
The following commits fix compatibility with Qiskit 2.0.

Some of the things addressed are:

- Removed usage of deprecated arguments `inst_map`, `backend_properties`, `instruction_durations`, and `timing_constraints` from calls to `generate_preset_passmanager`.
- Fix faulty conditional pass manager creation in `plugin.py`.
- Use `hasattr` to check if an operation is conditional, since in Qiskit 2.0 only `IfElseOp` and `WhileElseOp` contain this attribute.
- Due to the nature of some parts of the `DAGCircuit` thet live in Rust, the use of generators to get the bits of the dag has been removed. All generators are collected now. This is likely a bug with qiskit and not this plugin.