### PR TITLE
Docs: Update docs to specify package is available through pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ Before re-arranging a qubit, we need to check if there are any qubit that have b
 
 ## Installation
 
-This package is not available through pypi, but can be installed by cloning this repository:
+This package is available through pypi, and can be installed using the command:
+
+```zsh
+pip install qiskit-qubit-reuse
+```
+
+It can also be installed by cloning this repository:
 
 ```zsh
 git clone https://github.com/qiskit-community/qiskit-qubit-reuse


### PR DESCRIPTION
Fixes #7

A previous version of the Readme page pointed out that this package was absent from `pipy`. The package has been made available since then but no updates were made in respect to that. The following commits update the docstring to convey instructions as to how to install the package through pypi.