### PR TITLE
Pin compatibility to `qiskit>=1.0.0`

### DIFF
--- a/qiskit_qubit_reuse/qubit_reuse.py
+++ b/qiskit_qubit_reuse/qubit_reuse.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """QubitReuse pass to reduce the number of qubits on an QuantumCircuit"""
+
 import logging
 
 from qiskit.transpiler.basepasses import TransformationPass

--- a/qiskit_qubit_reuse/qubit_reuse_greedy.py
+++ b/qiskit_qubit_reuse/qubit_reuse_greedy.py
@@ -119,7 +119,7 @@ class Greedy:
                     for op_qubit in current_node.qargs:
                         self.__create_subpath(op_qubit, until_node=current_node)
                     # Apply the operation, check for condition
-                    if hasattr(current_node.op, "condition"):
+                    if getattr(current_node.op, "condition") is not None:
                         oper = copy.copy(current_node.op)
                         oper.condition = (self.__creg, oper.condition[1])
                     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qiskit>=0.43.0
-rustworkx>=0.12.0
+qiskit>=1.0.0
+rustworkx>=0.14.0


### PR DESCRIPTION
With recent updates, it has become way harder to ensure compatibility with Qiskit versions prior to the 1.0 release. The following commits pin the needed `qiskit` version to `>=1.0.0` as well as `>=0.14.0` for `rustworkx`.